### PR TITLE
Add support for capability instances

### DIFF
--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -102,9 +102,9 @@ create or replace function capability_instance_create(id text)
                instance_number_usages, instance_metadata
         from capabilities_http_instances where instance_id = iid
             into cname, start_date, end_date, max, meta;
-        msg := 'instance not active yet - instance_start_date: ' || start_date::text;
+        msg := 'instance not active yet - start time: ' || start_date::text;
         assert current_timestamp > start_date, msg;
-        msg := 'instance expirend_date - instance_end_date: ' || end_date::text;
+        msg := 'instance expired - end time: ' || end_date::text;
         if current_timestamp > end_date then
             delete from capabilities_http_instances where instance_id = iid;
             assert false, msg;

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -100,8 +100,8 @@ create trigger ensure_capabilities_http_instances_immutability before update on 
     for each row execute procedure capabilities_http_instances_immutability();
 
 
-drop function if exists capability_instance_create(text);
-create or replace function capability_instance_create(id text)
+drop function if exists capability_instance_get(text);
+create or replace function capability_instance_get(id text)
     returns json as $$
     declare iid uuid;
     declare cname text;

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -7,7 +7,7 @@ create or replace function drop_tables(drop_table_flag boolean default 'true')
         if drop_table_flag = 'true' then
             raise notice 'DROPPING CAPABILITIES TABLES';
             drop table if exists capabilities_http cascade;
-            drop table if exists capabilities_http_instances;
+            drop table if exists capabilities_http_instances cascade;
             drop table if exists capabilities_http_grants cascade;
         else
             raise notice 'NOT dropping tables - only functions will be replaced';

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -64,6 +64,15 @@ create table if not exists capabilities_http_instances(
 );
 
 
+drop function if exists capability_instance_get(text);
+create or replace funtion capability_instance_get(id text)
+    returns json as $$
+    begin
+        return '{}'::json;
+    end;
+$$ language plpgsql;
+
+
 drop table if exists capabilities_http_grants cascade;
 create table capabilities_http_grants(
     row_id uuid unique not null default gen_random_uuid(),

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -82,7 +82,7 @@ create table if not exists capabilities_http_instances(
 
 
 drop function if exists capability_instance_get(text);
-create or replace funtion capability_instance_get(id text)
+create or replace function capability_instance_get(id text)
     returns json as $$
     begin
         return '{}'::json;
@@ -90,7 +90,7 @@ create or replace funtion capability_instance_get(id text)
 $$ language plpgsql;
 
 
-create table capabilities_http_grants(
+create table if not exists capabilities_http_grants(
     row_id uuid unique not null default gen_random_uuid(),
     capability_name text references capabilities_http (capability_name) on delete cascade,
     capability_grant_id uuid not null default gen_random_uuid() primary key,

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -72,20 +72,28 @@ create trigger ensure_capabilities_http_group_check before insert or update on c
 
 
 create table if not exists capabilities_http_instances(
+    row_id uuid unique not null default gen_random_uuid(),
     capability_name text references capabilities_http (capability_name) on delete cascade,
     instance_id uuid unique not null default gen_random_uuid(),
-    instance_start_date timestamptz,
+    instance_start_date timestamptz default current_timestamp,
     instance_end_date timestamptz not null,
     instance_max_number_usages int,
     instance_metadata jsonb
 );
-
+-- add audit
+-- instance_id immutable
 
 drop function if exists capability_instance_get(text);
 create or replace function capability_instance_get(id text)
     returns json as $$
     begin
-        return '{}'::json;
+        -- if id not in table, exception
+        -- if current_timestamp < instance_start_date, refuse
+        -- if current_timestamp > instance_end_date, refuse, delete it
+        -- if instance_max_number_usages not null, decrement
+        -- if 0 after decrement delete it
+        -- return instance with associated info
+        return json_build_object('instance_id', id); -- and more
     end;
 $$ language plpgsql;
 

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -77,7 +77,7 @@ create table if not exists capabilities_http_instances(
     instance_id uuid unique not null default gen_random_uuid() primary key,
     instance_start_date timestamptz default current_timestamp,
     instance_end_date timestamptz not null,
-    instance_number_usages int,
+    instance_usages_remaining int,
     instance_metadata jsonb
 );
 
@@ -116,7 +116,7 @@ create or replace function capability_instance_create(id text)
         assert iid in (select instance_id from capabilities_http_instances),
             'instance not found';
         select capability_name, instance_start_date, instance_end_date,
-               instance_number_usages, instance_metadata
+               instance_usages_remaining, instance_metadata
         from capabilities_http_instances where instance_id = iid
             into cname, start_date, end_date, max, meta;
         msg := 'instance not active yet - start time: ' || start_date::text;
@@ -132,7 +132,7 @@ create or replace function capability_instance_create(id text)
             if new_max = 0 then
                 delete from capabilities_http_instances where instance_id = iid;
             else
-                update capabilities_http_instances set instance_number_usages = new_max
+                update capabilities_http_instances set instance_usages_remaining = new_max
                     where instance_id = iid;
             end if;
         end if;

--- a/db_identities_groups.sql
+++ b/db_identities_groups.sql
@@ -7,7 +7,7 @@ create or replace function drop_tables(drop_table_flag boolean default 'true')
     declare ans boolean;
     begin
         if drop_table_flag = 'true' then
-            raise notice 'DROPPING TABLES';
+            raise notice 'DROPPING IDENTITIES AND GROUPS TABLES';
             drop table if exists audit_log_objects cascade;
             drop table if exists audit_log_relations cascade;
             drop table if exists persons cascade;

--- a/db_identities_groups.sql
+++ b/db_identities_groups.sql
@@ -42,6 +42,8 @@ create table if not exists audit_log_objects_groups
     partition of audit_log_objects for values in ('groups');
 create table if not exists audit_log_objects_capabilities_http
     partition of audit_log_objects for values in ('capabilities_http');
+create table if not exists audit_log_objects_capabilities_http_instances
+    partition of audit_log_objects for values in ('capabilities_http_instances');
 
 
 create table if not exists audit_log_relations(

--- a/docs/1-data-model.md
+++ b/docs/1-data-model.md
@@ -8,16 +8,22 @@ Persons -----> Users ----> Groups (class:primary,   type:user)
                             -> Groups (class:primary,secondary,web
                                        relations: members, moderators)
 
-Capabilities -> Name
-             -> Required Groups
-             -> Grants (HTTP)
+Capabilities
+  -> Name
+  -> Required Groups
+  -> linked to
+    -> Instances (HTTP)
+    -> Grants (HTTP)
 
-Grants -> Capability Name
-       ->
-       ->
-       ->
-       -> HTTP method
-       -> URI pattern
+Capability Instances
+  -> a parameterised Capability
+
+Capability Grants
+ -> Capability Name
+ -> Host Name
+ -> Namespace identifier
+ -> HTTP method
+ -> URI pattern
 ```
 
 - `Persons`: root objects
@@ -55,7 +61,9 @@ Grants -> Capability Name
     - a capability can be obtained by a person or user who is a member of a set of specified requried groups
     - capabilities are linked to grants on resources
     - access control is therefore managed through group membership
-- Grants
+- Capability instances
+  - parameterised Capabilities, for use in generation of capability URLs
+- Capability grants
     - HTTP grants are linked to specific capabilities by their names
     - grant are grouped into sets
     - grant sets are defined by:

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -12,6 +12,7 @@ groups
 group_memberships
 group_moderators
 capabilities_http
+capabilities_http_instances
 capabilities_http_grants
 audit_log_objects
 audit_log_relations
@@ -106,5 +107,11 @@ capability_grant_delete(grant_id text)
 /*
     Returns:
     boolean
+*/
+
+capability_instance_create(id text)
+/*
+    Returns:
+    {capablity_name, instance_id, instance_start_date, instance_end_date, instance_usages_remaining, instance_metadata}
 */
 ```

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -109,7 +109,7 @@ capability_grant_delete(grant_id text)
     boolean
 */
 
-capability_instance_create(id text)
+capability_instance_get(id text)
 /*
     Returns:
     {capablity_name, instance_id, instance_start_date, instance_end_date, instance_usages_remaining, instance_metadata}

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,11 @@ setup() {
     num_grants=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from capabilities_http_grants" -At)
     echo "Capabilities: $num_caps"
     echo "Grants: $num_grants"
-    read -p 'Do you want to (re)install the capabilities functionality (thereby dropping existing data)? (y/n) > ' ANS
+    if [[ $DROP_TABLES == "true" ]]; then
+        read -p 'Do you want to (re)install the capabilities functionality (thereby dropping existing data)? (y/n) > ' ANS
+    else
+        read -p 'Do you want to (re)install the capabilities functions (no table data will be lost)? (y/n) > ' ANS
+    fi
     if [[ $ANS == "y" ]]; then
         psql -h $DBHOST -U $DBOWNER -d $DBNAME -1 -f ./db_capabilities.sql
     fi

--- a/tests.sql
+++ b/tests.sql
@@ -821,7 +821,26 @@ create or replace function test_capability_instances()
         begin
             select capability_instance_create(iid::text) into instance;
         exception when assert_failure then
-            raise notice 'cannot use expired capability instance - as expected';
+            raise notice 'cannot use capability instance before start time - as expected';
+        end;
+        -- immutable cols
+        begin
+            update capabilities_http_instances set row_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
+                where instance_id = iid;
+        exception when assert_failure then
+            raise notice 'capabilities_http_instances: row_id immutable';
+        end;
+        begin
+            update capabilities_http_instances set capability_name = 'parsley'
+                where instance_id = iid;
+        exception when assert_failure then
+            raise notice 'capabilities_http_instances: capability_name immutable';
+        end;
+        begin
+            update capabilities_http_instances set instance_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
+                where instance_id = iid;
+        exception when assert_failure then
+            raise notice 'capabilities_http_instances: instance_id immutable';
         end;
         return true;
     end;

--- a/tests.sql
+++ b/tests.sql
@@ -783,7 +783,7 @@ create or replace function test_capability_instances()
         values ('export', now() - interval '1 hour', current_timestamp + '2 hours',
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;
-        select capability_instance_create(iid::text) into instance;
+        select capability_instance_get(iid::text) into instance;
         -- decrementing instance_usages_remaining
         assert (select instance_usages_remaining from capabilities_http_instances
                 where instance_id = iid) = 2,
@@ -791,10 +791,10 @@ create or replace function test_capability_instances()
         assert instance->>'instance_usages_remaining' = 2::text,
             'instance_usages_remaining incorrectly reported by instance creation function';
         -- auto deletion
-        select capability_instance_create(iid::text) into instance;
-        select capability_instance_create(iid::text) into instance;
+        select capability_instance_get(iid::text) into instance;
+        select capability_instance_get(iid::text) into instance;
         begin
-            select capability_instance_create(iid::text) into instance;
+            select capability_instance_get(iid::text) into instance;
         exception when assert_failure then
             raise notice 'automatic deletion of capability instances works';
         end;
@@ -806,7 +806,7 @@ create or replace function test_capability_instances()
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;
         begin
-            select capability_instance_create(iid::text) into instance;
+            select capability_instance_get(iid::text) into instance;
         exception when assert_failure then
             raise notice 'cannot use expired capability instance - as expected';
         end;
@@ -819,7 +819,7 @@ create or replace function test_capability_instances()
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;
         begin
-            select capability_instance_create(iid::text) into instance;
+            select capability_instance_get(iid::text) into instance;
         exception when assert_failure then
             raise notice 'cannot use capability instance before start time - as expected';
         end;

--- a/tests.sql
+++ b/tests.sql
@@ -779,15 +779,15 @@ create or replace function test_capability_instances()
     begin
         insert into capabilities_http_instances
             (capability_name, instance_start_date, instance_end_date,
-             instance_number_usages, instance_metadata)
+             instance_usages_remaining, instance_metadata)
         values ('export', now() - interval '1 hour', current_timestamp + '2 hours',
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;
         select capability_instance_create(iid::text) into instance;
-        -- decrementing instance_number_usages
-        assert (select instance_number_usages from capabilities_http_instances
+        -- decrementing instance_usages_remaining
+        assert (select instance_usages_remaining from capabilities_http_instances
                 where instance_id = iid) = 2,
-            'instance_number_usages not being decremented after instance creation';
+            'instance_usages_remaining not being decremented after instance creation';
         assert instance->>'instance_usages_remaining' = 2::text,
             'instance_usages_remaining incorrectly reported by instance creation function';
         -- auto deletion
@@ -801,7 +801,7 @@ create or replace function test_capability_instances()
         -- cannot use if expired
         insert into capabilities_http_instances
             (capability_name, instance_start_date, instance_end_date,
-             instance_number_usages, instance_metadata)
+             instance_usages_remaining, instance_metadata)
         values ('export', now() - interval '3 hour', now() - interval '2 hour',
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;
@@ -814,7 +814,7 @@ create or replace function test_capability_instances()
         -- cannot use if not active yet
         insert into capabilities_http_instances
             (capability_name, instance_start_date, instance_end_date,
-             instance_number_usages, instance_metadata)
+             instance_usages_remaining, instance_metadata)
         values ('export', now() + interval '3 hour', now() + interval '4 hour',
                 3, '{"claims": {"proj": "p11", "user": "p11-anonymous"}}');
         select instance_id from capabilities_http_instances into iid;


### PR DESCRIPTION
This completes the `capabilities_http_instances` table, its triggers, the helper function for instance creation (`capability_instance_get`), and adds tests. The audit table is also updated.