### PR TITLE
capabilities and grant improvements

### DIFF
--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -447,7 +447,32 @@ $$ language plpgsql;
 drop function if exists capability_grant_group_remove(text, text);
 create or replace function capability_grant_group_remove(grant_reference text, group_name text)
     returns boolean as $$
+    declare current text[];
+    declare new text[];
+    declare num int;
     begin
+        begin
+            perform grant_reference::uuid;
+            select count(*) from capabilities_http_grants
+                where capability_grant_id = grant_reference::uuid into num;
+            assert num = 1, 'grant not found';
+            select capability_grant_required_groups from capabilities_http_grants
+                where capability_grant_id = grant_reference::uuid into current;
+            select array_remove(current, group_name) into new;
+            if cardinality(new) = 0 then new := null; end if;
+            update capabilities_http_grants set capability_grant_required_groups = new
+                where capability_grant_id = grant_reference::uuid;
+        exception when invalid_text_representation then
+            select count(*) from capabilities_http_grants
+                where capability_grant_name = grant_reference into num;
+            assert num = 1, 'grant not found';
+            select capability_grant_required_groups from capabilities_http_grants
+                where capability_grant_name = grant_reference into current;
+            select array_remove(current, group_name) into new;
+            if cardinality(new) = 0 then new := null; end if;
+            update capabilities_http_grants set capability_grant_required_groups = new
+                where capability_grant_name = grant_reference;
+        end;
         return true;
     end;
 $$ language plpgsql;

--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -195,7 +195,18 @@ create table if not exists capabilities_http_grants(
             capability_grant_http_method,
             capability_grant_rank)
 );
--- todo: array_unique on groups
+
+drop function if exists ensure_unique_grant_groups() cascade;
+create or replace function ensure_unique_grant_groups()
+    returns trigger as $$
+    begin
+        perform assert_array_unique(NEW.capability_grant_required_groups, 'capability_grant_required_groups');
+        return new;
+    end;
+$$ language plpgsql;
+create trigger capabilities_http_grants_unique_groups before update or insert on capabilities_http_grants
+    for each row execute procedure ensure_unique_grant_groups();
+
 
 drop function if exists ensure_sensible_rank_update() cascade;
 create or replace function ensure_sensible_rank_update()

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -108,4 +108,16 @@ capability_instance_get(id text)
     Returns:
     {capablity_name, instance_id, instance_start_date, instance_end_date, instance_usages_remaining, instance_metadata}
 */
+
+capability_grant_group_add(grant_reference text, group_name text)
+/*
+    Returns
+    boolean
+*/
+
+capability_grant_group_remove(grant_reference text, group_name text)
+/*
+    Returns
+    boolean
+*/
 ```

--- a/tests.sql
+++ b/tests.sql
@@ -725,12 +725,18 @@ create or replace function test_capabilities_http()
         assert (select capability_grant_rank from capabilities_http_grants
                 where capability_grant_id = grid4) = 3, 'rank delete issue - id4';
         -- test self and moderator keywords
-        insert into capabilities_http_grants (capability_grant_hostname, capability_grant_namespace,
+        insert into capabilities_http_grants (capability_grant_name,
+                                              capability_grant_hostname, capability_grant_namespace,
                                               capability_grant_http_method, capability_grant_uri_pattern,
                                               capability_grant_required_groups)
-                                      values ('api.com', 'files',
+                                      values ('allow_get',
+                                              'api.com', 'files',
                                               'GET', '/(.*)/admin/profile/([a-zA-Z0-9])',
-                                              '{"self","moderator"}');
+                                              '{"self"}');
+        select capability_grant_group_add('allow_get', 'moderator') into ans;
+        -- test group content
+        -- test can use id
+        -- test remove with both name and id
         return true;
     end;
 $$ language plpgsql;

--- a/tests.sql
+++ b/tests.sql
@@ -750,7 +750,7 @@ create or replace function test_capabilities_http()
                                               capability_grant_hostname, capability_grant_namespace,
                                               capability_grant_http_method, capability_grant_uri_pattern,
                                               capability_grant_required_groups)
-                                      values ('{export}',
+                                      values ('{export,admin}',
                                               'allow_get',
                                               'api.com', 'files',
                                               'GET', '/(.*)/admin/profile/([a-zA-Z0-9])',
@@ -762,6 +762,7 @@ create or replace function test_capabilities_http()
         select capability_grant_group_remove(grid1::text, 'moderator') into ans;
         assert array['self'] = (select capability_grant_required_groups from capabilities_http_grants
                                 where capability_grant_name = 'allow_get'), 'capability_grant_group_remove issue';
+        -- test that deleting a capability_name automatically removes it from any references in capability_names_allowed
         return true;
     end;
 $$ language plpgsql;

--- a/tests.sql
+++ b/tests.sql
@@ -672,6 +672,12 @@ create or replace function test_capabilities_http()
         exception when others then
             raise notice 'capabilities_http_grants: rank values must be unique within their grant sets - as expected';
         end;
+        begin
+            update capabilities_http_grants set capability_grant_required_groups = '{sefl,self}'
+                where capability_grant_id = grid;
+        exception when assert_failure then
+            raise notice 'capabilities_http_grants: groups are ensured to be unique';
+        end;
         -- reject if grant id not found
         begin
             select capability_grant_rank_set(grid::text, 9) into ans;

--- a/tests.sql
+++ b/tests.sql
@@ -734,10 +734,12 @@ create or replace function test_capabilities_http()
                                               'GET', '/(.*)/admin/profile/([a-zA-Z0-9])',
                                               '{"self"}');
         select capability_grant_group_add('allow_get', 'moderator') into ans;
-        -- test group content
-        -- test can use id
-        select capability_grant_group_remove('allow_get', 'moderator') into ans;
-        -- test remove with both name and id
+        assert array['moderator'] <@ (select capability_grant_required_groups from capabilities_http_grants
+                                      where capability_grant_name = 'allow_get'), 'capability_grant_group_add issue';
+        select capability_grant_id from capabilities_http_grants where capability_grant_name = 'allow_get' into grid1;
+        select capability_grant_group_remove(grid1::text, 'moderator') into ans;
+        assert array['self'] = (select capability_grant_required_groups from capabilities_http_grants
+                                where capability_grant_name = 'allow_get'), 'capability_grant_group_remove issue';
         return true;
     end;
 $$ language plpgsql;

--- a/tests.sql
+++ b/tests.sql
@@ -533,6 +533,12 @@ create or replace function test_capabilities_http()
         exception when others then
             raise notice 'capabilities_http: name uniqueness guaranteed';
         end;
+        begin
+            update capabilities_http set capability_required_groups = '{self,self}'
+                where capability_name = 'admin';
+        exception when assert_failure then
+            raise notice 'capabilities_http: required groups are guaranteed unique';
+        end;
         -- referential constraints
         begin
             insert into capabilities_http (capability_name, capability_default_claims,

--- a/tests.sql
+++ b/tests.sql
@@ -736,6 +736,7 @@ create or replace function test_capabilities_http()
         select capability_grant_group_add('allow_get', 'moderator') into ans;
         -- test group content
         -- test can use id
+        select capability_grant_group_remove('allow_get', 'moderator') into ans;
         -- test remove with both name and id
         return true;
     end;


### PR DESCRIPTION
* redo reference between capabilities and the grants which apply to them
    * this used to be one-to-many
    * now it is many-to-many
    * allow usage of `all` keyword
* ensure required_groups are unique
* enhancements to the `capabilities_http_grants` table
    * add column `capability_grant_name` for easy programmatic use
    * add column `capability_grant_quick` for configurable evaluation
    * more robust implementation of grant ranks
    * helper functions for adding and removing required_groups
* update tests to cover changes, and additions