### PR TITLE
Add capability_hosts column to capabilities_http table

### DIFF
--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -35,6 +35,7 @@ create table if not exists capabilities_http(
     row_id uuid unique not null default gen_random_uuid(),
     capability_id uuid unique not null default gen_random_uuid(),
     capability_name text unique not null primary key,
+    capability_hostnames text[] not null,
     capability_default_claims jsonb,
     capability_required_groups text[],
     capability_required_attributes jsonb,
@@ -47,16 +48,17 @@ create table if not exists capabilities_http(
 );
 
 
-drop function if exists ensure_unique_capability_groups() cascade;
-create or replace function ensure_unique_capability_groups()
+drop function if exists ensure_unique_capability_attributes() cascade;
+create or replace function ensure_unique_capability_attributes()
     returns trigger as $$
     begin
         perform assert_array_unique(NEW.capability_required_groups, 'capability_required_groups');
+        perform assert_array_unique(NEW.capability_hostnames, 'capability_hostnames');
         return new;
     end;
 $$ language plpgsql;
 create trigger capabilities_http_unique_groups before update or insert on capabilities_http
-    for each row execute procedure ensure_unique_capability_groups();
+    for each row execute procedure ensure_unique_capability_attributes();
 
 
 create trigger capabilities_http_audit after update or insert or delete on capabilities_http

--- a/install.sh
+++ b/install.sh
@@ -58,9 +58,9 @@ setup() {
         psql -h $DBHOST -U $DBOWNER -d $DBNAME -1 -f ./db_capabilities.sql
         exit
     fi
-    num_persons=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from persons" -At)
-    num_users=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from users" -At)
-    num_groups=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from groups" -At)
+    num_persons=$(psql -h $DBHOST -U $DBOWNER -d $DBNAME -c "select count(*) from persons" -At)
+    num_users=$(psql -h $DBHOST -U $DBOWNER -d $DBNAME -c "select count(*) from users" -At)
+    num_groups=$(psql -h $DBHOST -U $DBOWNER -d $DBNAME -c "select count(*) from groups" -At)
     echo "Persons: $num_persons"
     echo "Users: $num_users"
     echo "Groups: $num_groups"
@@ -72,8 +72,8 @@ setup() {
     if [[ $ANS == "y" ]]; then
         psql -h $DBHOST -U $DBOWNER -d $DBNAME -1 -f ./db_identities_groups.sql
     fi
-    num_caps=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from capabilities_http" -At)
-    num_grants=$(psql -h $DBHOST -U $SUPERUSER -d $DBNAME -c "select count(*) from capabilities_http_grants" -At)
+    num_caps=$(psql -h $DBHOST -U $DBOWNER -d $DBNAME -c "select count(*) from capabilities_http" -At)
+    num_grants=$(psql -h $DBHOST -U $DBOWNER -d $DBNAME -c "select count(*) from capabilities_http_grants" -At)
     echo "Capabilities: $num_caps"
     echo "Grants: $num_grants"
     if [[ $DROP_TABLES == "true" ]]; then

--- a/tests.sql
+++ b/tests.sql
@@ -490,22 +490,22 @@ create or replace function test_capabilities_http()
     declare grid3 uuid;
     declare grid4 uuid;
     begin
-        insert into capabilities_http (capability_name, capability_default_claims,
+        insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date)
-            values ('p11import', '{"role": "p11_import_user"}',
+            values ('p11import', '{api.com}', '{"role": "p11_import_user"}',
                     '{"p11-export-group", "p11-special-group"}', 'exact',
                     '123', 'bla', current_date);
-        insert into capabilities_http (capability_name, capability_default_claims,
+        insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date)
-            values ('export', '{"role": "export_user"}',
+            values ('export', '{api.com}', '{"role": "export_user"}',
                     '{"admin-group", "export-group"}', 'wildcard',
                     '123', 'bla', current_date);
-        insert into capabilities_http (capability_name, capability_default_claims,
+        insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date)
-            values ('admin', '{"role": "admin_user"}',
+            values ('admin', '{api.com}', '{"role": "admin_user"}',
                     '{"admin-group", "special-group"}', 'wildcard',
                     '123', 'bla', current_date);
         -- immutability
@@ -523,10 +523,10 @@ create or replace function test_capabilities_http()
         end;
         -- uniqueness
         begin
-            insert into capabilities_http (capability_name, capability_default_claims,
+            insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date)
-                values ('admin', '{"role": "admin_user"}',
+                values ('admin', '{api.com}', '{"role": "admin_user"}',
                         '{"admin-group", "special-group"}', 'wildcard',
                         '123', 'bla', current_date);
             assert false;
@@ -541,10 +541,10 @@ create or replace function test_capabilities_http()
         end;
         -- referential constraints
         begin
-            insert into capabilities_http (capability_name, capability_default_claims,
+            insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date)
-            values ('admin2', '{"role": "admin_user"}',
+            values ('admin2', '{api.com}', '{"role": "admin_user"}',
                     '{"admin2-group", "very-special-group"}', 'wildcard',
                     '123', 'bla', current_date);
             assert false;
@@ -552,11 +552,11 @@ create or replace function test_capabilities_http()
             raise notice 'capabilities_http: group must exist to be referenced in new capability';
         end;
         -- ability to override group references
-        insert into capabilities_http (capability_name, capability_default_claims,
+        insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                   capability_required_groups, capability_group_match_method,
                                   capability_lifetime, capability_description, capability_expiry_date,
                                   capability_group_existence_check)
-            values ('admin2', '{"role": "admin_user"}',
+            values ('admin2', '{api.com}', '{"role": "admin_user"}',
                     '{"admin2-group", "very-special-group"}', 'wildcard',
                     '123', 'bla', current_date, 'f');
         delete from capabilities_http where capability_name = 'admin2';
@@ -763,10 +763,10 @@ create or replace function test_capabilities_http()
         assert array['self'] = (select capability_grant_required_groups from capabilities_http_grants
                                 where capability_grant_name = 'allow_get'), 'capability_grant_group_remove issue';
         -- test that deleting a capability_name automatically removes it from any references in capability_names_allowed
-        insert into capabilities_http (capability_name, capability_default_claims,
+        insert into capabilities_http (capability_name, capability_hostnames, capability_default_claims,
                                        capability_required_groups, capability_group_match_method,
                                        capability_lifetime, capability_description, capability_expiry_date)
-                               values ('edit', '{"role": "editor"}',
+                               values ('edit', '{api.com}', '{"role": "editor"}',
                                       '{"p11-export-group", "p11-special-group"}', 'exact',
                                       '123', 'bla', current_date);
         insert into capabilities_http_grants (capability_names_allowed,
@@ -909,10 +909,10 @@ create or replace function test_funcs()
         assert data->>'person_id' = pid::text, err;
         -- person_capabilities
         insert into capabilities_http (
-            capability_name, capability_default_claims,
+            capability_name, capability_hostnames, capability_default_claims,
             capability_required_groups, capability_group_match_method,
             capability_lifetime, capability_description, capability_expiry_date)
-            values ('p11-art', '{"role": "p11_art_user"}',
+            values ('p11-art', '{api.com}', '{"role": "p11_art_user"}',
                     '{"p11-surrealist-group", "p11-admin-group"}', 'exact',
                     '123', 'bla', current_date);
         insert into capabilities_http_grants (capability_names_allowed,


### PR DESCRIPTION
This allows for more flexible capability definition. Most notably, one can reuse grants, with with different group requirements attached to different capabilities, depending on the hostname. 

For example, the same API might be accessible from two hosts `A` and `B`, where the former might serve a client network with a low level of trust, and the latter a high level of trust. At the same time one could enable access to the same API operations from both networks. With the new column one can define per host capabilities `C(A)` and `C(B)`, each only available at a specific host. One could then require group membership with high privileges for the network with a low level of trust: `C(A, high)`, and lower privileges for the high trust network `C(B, low)`. Finally, one could apply the same API grant to both `C(A)` and `C(B)` while maintaining different and appropriate security levels.