### PR TITLE
Constraint cleanup, client version of self for grants

### DIFF
--- a/db_capabilities.sql
+++ b/db_capabilities.sql
@@ -191,7 +191,7 @@ create table if not exists capabilities_http_grants(
     capability_grant_quick boolean default 't',
     capability_grant_start_date timestamptz,
     capability_grant_end_date timestamptz,
-    capability_grant_max_num_usages int,
+    capability_grant_max_num_usages int check (capability_grant_max_num_usages >= 0),
     capability_grant_group_existence_check boolean default 't',
     capability_grant_metadata jsonb,
     unique (capability_grant_namespace,
@@ -325,7 +325,7 @@ create or replace function capabilities_http_grants_group_check()
         end if;
         for new_grp in select unnest(NEW.capability_grant_required_groups) loop
             select count(*) from groups where group_name like '%' || new_grp || '%' into num;
-            if new_grp not in ('self', 'moderator') then
+            if new_grp not in ('self', 'moderator', 'client') then
                 assert num > 0, new_grp || ' does not exist';
             end if;
         end loop;

--- a/db_identities_groups.sql
+++ b/db_identities_groups.sql
@@ -259,8 +259,6 @@ create or replace function generate_new_posix_id(table_name text, colum_name tex
             new_id := 1000;
         elsif current_max_id >= 0 and current_max_id <= 999 then
             new_id := 1000;
-        elsif current_max_id >= 200000 and current_max_id <= 220000 then
-            new_id := 220001;
         else
             new_id := current_max_id + 1;
         end if;
@@ -291,7 +289,6 @@ create table if not exists users(
     user_name text unique not null primary key,
     user_group text,
     user_posix_uid int unique
-        check ((user_posix_uid > 999 and user_posix_uid < 200000) or user_posix_uid > 220000)
         default generate_new_posix_uid(), -- note: can still create holes
     user_group_posix_gid int
         check ((user_group_posix_gid > 999 and user_group_posix_gid < 200000) or user_group_posix_gid > 220000),
@@ -407,7 +404,6 @@ create table if not exists groups(
     group_primary_member text,
     group_description text,
     group_posix_gid int unique -- person groups do not have gids
-        check ((group_posix_gid > 999 and group_posix_gid < 200000) or group_posix_gid > 220000),
     group_metadata jsonb
 );
 

--- a/tests.sql
+++ b/tests.sql
@@ -57,12 +57,6 @@ create or replace function test_persons_users_groups()
             raise notice 'cannot assign gid between 0 and 999, as expected';
         end;
         begin
-            insert into groups (group_name, group_type, group_posix_gid)
-                values ('g1', 'generic', 200001);
-        exception when others then
-            raise notice 'cannot assign gid between 200000 and 220000, as expected';
-        end;
-        begin
             update groups set group_posix_gid = '2000' where group_name = 'p11-sconne-group';
             assert false;
         exception when others then
@@ -229,32 +223,32 @@ create or replace function test_group_memeberships_moderators()
     begin
         -- create persons and users
         insert into persons (full_name, person_expiry_date)
-            values ('Sarah Conner', '2020-10-01');
+            values ('Sarah Conner', '2050-10-01');
         select person_id from persons where full_name like '%Conner' into pid;
         insert into users (person_id, user_name, user_expiry_date)
-            values (pid, 'p11-sconne', '2020-03-28');
+            values (pid, 'p11-sconne', '2050-03-28');
         insert into users (person_id, user_name, user_expiry_date)
             values (pid, 'p66-sconne', '2019-12-01');
         insert into persons (full_name, person_expiry_date)
-            values ('John Conner2', '2020-10-01');
+            values ('John Conner2', '2050-10-01');
         select person_id from persons where full_name like '%Conner2' into pid;
         insert into users (person_id, user_name, user_expiry_date)
-            values (pid, 'p11-jconn', '2020-03-28');
+            values (pid, 'p11-jconn', '2050-03-28');
         insert into persons (full_name, person_expiry_date)
-            values ('Frank Castle', '2020-10-01');
+            values ('Frank Castle', '2050-10-01');
         select person_id from persons where full_name like '%Castle' into pid;
         insert into users (person_id, user_name, user_expiry_date)
-            values (pid, 'p11-fcl', '2020-03-28');
+            values (pid, 'p11-fcl', '2050-03-28');
         insert into persons (full_name, person_expiry_date)
-            values ('Virginia Woolf', '2020-10-01');
+            values ('Virginia Woolf', '2050-10-01');
         select person_id from persons where full_name like '%Woolf' into pid;
         insert into users (person_id, user_name, user_expiry_date)
-            values (pid, 'p11-vwf', '2020-03-28');
+            values (pid, 'p11-vwf', '2050-03-28');
         insert into persons (full_name, person_expiry_date)
-            values ('David Gilgamesh', '2020-10-01');
+            values ('David Gilgamesh', '2050-10-01');
         select person_id from persons where full_name like '%Gilgamesh' into pid;
         insert into users (person_id, user_name, user_expiry_date)
-            values (pid, 'p11-dgmsh', '2020-03-28');
+            values (pid, 'p11-dgmsh', '2050-03-28');
         -- create groups
         insert into groups (group_name, group_class, group_type)
             values ('p11-admin-group', 'secondary', 'generic');


### PR DESCRIPTION
* add check for `capability_grant_max_num_usages`
* remove uid and gid constraints for ranges above 1000 - can be handled in the application
* add a `client` equivalent of `self`
* update tests