### PR TITLE
audit tables now use current_timestamp instead of now()

### DIFF
--- a/mgrt/1.5-to-2.0.sql
+++ b/mgrt/1.5-to-2.0.sql
@@ -18,3 +18,8 @@ alter table groups add constraint groups_group_posix_gid_check check (group_posi
 drop trigger capabilities_http_grants_audit on capabilities_http_grants;
 create trigger capabilities_http_grants_audit after update or insert or delete on capabilities_http_grants
     for each row execute procedure update_audit_log_objects();
+
+-- change now() to current_timestamp
+-- (to not be affected by session-speifics)
+alter table audit_log_objects alter column event_time set default current_timestamp;
+alter table audit_log_relations alter column event_time set default current_timestamp;

--- a/src/audit.sql
+++ b/src/audit.sql
@@ -22,7 +22,7 @@ select drop_tables(:drop_table_flag);
 create table if not exists audit_log_objects(
     identity text default null,
     operation text not null,
-    event_time timestamptz default now(),
+    event_time timestamptz default current_timestamp,
     table_name text not null,
     row_id uuid not null,
     column_name text,
@@ -50,7 +50,7 @@ create table if not exists audit_log_objects_projects
 create table if not exists audit_log_relations(
     identity text default null,
     operation text not null,
-    event_time timestamptz default now(),
+    event_time timestamptz default current_timestamp,
     table_name text not null,
     parent text,
     child text


### PR DESCRIPTION
More robust to transaction, and/or session specific details.