### PR TITLE
Temporal group relations

### DIFF
--- a/docs/1-data-model.md
+++ b/docs/1-data-model.md
@@ -40,6 +40,10 @@ Projects     -> Groups (class:secondary type:generic,web)
         - groups can be members of other groups
         - persons and/or user are members of other groups via their person or user groups, not directly
         - this can form Directed Acyclic Graphs
+        - memberships can have temporal constraints:
+            - start date: when the membership becomes active
+            - end date: after which the membership becomes inactive
+            - can be limited to being active between specific hours on a specific day of the week
     - moderator
         - groups can moderate other groups, but not transitively or cyclically
 - Activation

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -27,7 +27,11 @@ To investigate the tables more, it is best to install `pg-iam` and inspect the D
 To ease routine tasks for getting information, `pg-iam` provides a set of helper functions which combine information from various tables.
 
 ```sql
-person_groups(person_id text)
+person_groups(
+    person_id text,
+    filter_memberships boolean default 'false',
+    client_timestamp timestamptz default current_timestamp
+)
 /*
     Returns:
     {person_id: '', person_groups: []}
@@ -45,7 +49,11 @@ person_access(person_id text)
     {person_id: '', person_access: {person_group_access: [], users_groups_access: []}}
 */
 
-user_groups(user_name text)
+user_groups(
+    user_name text,
+    filter_memberships boolean default 'false',
+    client_timestamp timestamptz default current_timestamp
+)
 /*
     Returns:
     {user_name: '', user_groups: []}
@@ -63,7 +71,11 @@ user_capabilities(user_name text, grants boolean)
     {user_name: '', user_capabilities: []}
 */
 
-group_members(group_name text)
+group_members(
+    group_name text,
+    filter_memberships boolean default 'false',
+    client_timestamp timestamptz default current_timestamp
+)
 /*
     Returns:
     {direct_members: [], transitive_members: [], ultimate_members: []}
@@ -75,7 +87,13 @@ group_moderators(group_name text)
     {group_name: '', group_moderators: []}
 */
 
-group_member_add(group_name text, member text)
+group_member_add(
+    group_name text,
+    member text,
+    start_date timestamptz default null,
+    end_date timestamptz default null,
+    weekdays jsonb default null
+)
 /*
     Returns:
     {message: ''}

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -92,7 +92,7 @@ group_member_add(
     member text,
     start_date timestamptz default null,
     end_date timestamptz default null,
-    weekdays jsonb default null
+    weekdays jsonb default null -- e.g. {"mon": {"start": "08:00", "end": "17:00"}}
 )
 /*
     Returns:

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -2,6 +2,7 @@
 alter table group_memberships add column if not exists start_date timestamptz;
 alter table group_memberships add column if not exists end_date timestamptz;
 alter table group_memberships add column if not exists weekdays jsonb;
+alter table group_memberships add constraint group_memberships_check check (start_date < end_date);
 
 alter table audit_log_relations add column if not exists start_date timestamptz;
 alter table audit_log_relations add column if not exists end_date timestamptz;

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -1,0 +1,3 @@
+
+alter table group_memberships add column if not exists start_date timestamptz;
+alter table group_memberships add column if not exists end_date timestamptz;

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -2,3 +2,7 @@
 alter table group_memberships add column if not exists start_date timestamptz;
 alter table group_memberships add column if not exists end_date timestamptz;
 alter table group_memberships add column if not exists weekdays jsonb;
+
+alter table audit_log_relations add column if not exists start_date timestamptz;
+alter table audit_log_relations add column if not exists end_date timestamptz;
+alter table audit_log_relations add column if not exists weekdays jsonb;

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -1,3 +1,4 @@
 
 alter table group_memberships add column if not exists start_date timestamptz;
 alter table group_memberships add column if not exists end_date timestamptz;
+alter table group_memberships add column if not exists weekdays jsonb;

--- a/src/identities.sql
+++ b/src/identities.sql
@@ -596,6 +596,11 @@ create or replace function include_membership(
         if filter_inactive = 'false' then
             return 'true';
         end if;
+        if client_timestamp not between
+            (current_timestamp at time zone '-12')
+            and (current_timestamp at time zone '+14') then
+            raise exception using message = 'impossible client_timestamp';
+        end if;
         select group_expiry_date, group_activated from groups
             where group_name = source_group into source_exp, source_activated;
         select group_expiry_date, group_activated from groups

--- a/tests.sql
+++ b/tests.sql
@@ -1095,13 +1095,6 @@ create or replace function test_projects()
             raise notice 'projects: project_number immutable';
         end;
         begin
-            update projects set project_name = 'lovecats'
-                where project_name = 'raka';
-            assert false, 'projects: project_name mutable';
-        exception when others then
-            raise notice 'projects: project_name immutable';
-        end;
-        begin
             update projects set project_group = 'some-group'
                 where project_name = 'raka';
             assert false, 'projects: project_group mutable';


### PR DESCRIPTION
# Use cases

To grant a privilege that:
1. lasts for a specific duration, e.g. for the duration of an employment contract
2. can only be used during work hours

# Summary

This PR adds optional temporal constraints to group memberships:

* start date: before which a membership is inactive
* end date: after which a membership is inactive
* weekday + time of day: e.g. "Monday and Tuesdays, from 08:00 until 17:00"
* specifying the `client_timestamp` in the call allows to applying constraints relative to specific time zones - the DB checks for unrealistic time zone differences
* `audit_log_relations` table is updated to contain membership constraint information too
* all changes are backward compatible

The following DB function signatures gain optional parameters which will apply temporal constraints if so asked:

```sql
person_groups(
    person_id text,
    filter_memberships boolean default 'false',
    client_timestamp timestamptz default current_timestamp
)

user_groups(
    user_name text,
    filter_memberships boolean default 'false',
    client_timestamp timestamptz default current_timestamp
)

group_members(
    group_name text,
    filter_memberships boolean default 'false',
    client_timestamp timestamptz default current_timestamp
)

group_member_add(
    group_name text,
    member text,
    start_date timestamptz default null,
    end_date timestamptz default null,
    weekdays jsonb default null
)
```
[Membership filtering](https://github.com/unioslo/pg-iam/blob/6489df922a315fafa6df3e90e8a3ab89256bff6e/src/identities.sql#L587-L627) is applied if:

* either a source or destination group is expired or inactive
* the client_timestamp is before or after start and end date
* a week day restriction is present and is not active


For example usage see the [tests](https://github.com/unioslo/pg-iam/blob/6489df922a315fafa6df3e90e8a3ab89256bff6e/tests.sql#L472-L702) and [docs](https://github.com/unioslo/pg-iam/blob/6489df922a315fafa6df3e90e8a3ab89256bff6e/docs/3-example.md).
