### PR TITLE
Improve error handling, more accurate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A generic database backend for use in IAM APIs.
 # Features
 
 - create persons, users, and groups with optional expiry dates, and activation states
-- add users and/or groups to groups
+- add users and/or groups to groups, specify temporal constraints on memberships
 - add persons without users to groups, for external account access control management
 - allow groups to moderate memberships of other groups
 - create capabilities, criteria for obtaining them, use them in access tokens
@@ -20,14 +20,14 @@ A generic database backend for use in IAM APIs.
 Read the guide on how to install and run tests.
 
 ```bash
-git clone git@github.com:leondutoit/pg-iam.git
+git clone git@github.com:unioslo/pg-iam.git
 cd pg-iam
 ./install.sh --guide
 ```
 
 # Learn more
 
-Read the [docs](https://github.com/leondutoit/pg-iam/tree/master/docs).
+Read the [docs](https://github.com/unioslo/pg-iam/tree/master/docs).
 
 # LICENSE
 

--- a/src/identities.sql
+++ b/src/identities.sql
@@ -859,36 +859,47 @@ create or replace function group_memberships_check_dag_requirements()
     returns trigger as $$
     declare response text;
     begin
+        -- Ensure we have only Directed Acylic Graphs
         if (
             NEW.group_name not in (select group_name from groups)
             or NEW.group_member_name not in (select group_name from groups)
         ) then
             return new; -- foreign key constraint will stop it
+        elsif NEW.group_name = NEW.group_member_name then
+            raise integrity_constraint_violation
+                using message = 'groups cannot be members of themselves';
+        elsif (select NEW.group_name in (select group_name from groups where group_class = 'primary')) then
+            raise integrity_constraint_violation
+                using message = NEW.group_name || ' is a primary group, primary member already set';
+        elsif (select group_activated from groups where group_name = NEW.group_name) = 'f' then
+            raise integrity_constraint_violation
+                using message = NEW.group_name || ' is deactived, no new memberships allowed';
+        elsif (select group_activated from groups where group_name = NEW.group_member_name) = 'f' then
+            raise integrity_constraint_violation
+                using message = NEW.group_member_name || ' is deactived, no new memberships allowed';
+        elsif (
+            (select case when group_expiry_date is not null then group_expiry_date else current_date end
+             from groups where group_name = NEW.group_name) < current_date
+        ) then
+            raise integrity_constraint_violation
+                using message = NEW.group_name || ' has expired, no new memberships allowed';
+        elsif (
+            (select case when group_expiry_date is not null then group_expiry_date else current_date end
+             from groups where group_name = NEW.group_member_name) < current_date
+        ) then
+            raise integrity_constraint_violation
+                using message = NEW.group_member_name || ' has expired, no new memberships allowed';
+        elsif (
+            (select NEW.group_member_name in (select member_group_name from group_get_parents(NEW.group_name))) = 't'
+        ) then
+            raise integrity_constraint_violation
+                using message =  NEW.group_name || ' is a member of ' || NEW.group_member_name || ' - cyclical memberships not allowed';
+        elsif (
+            (select NEW.group_member_name in (select group_member_name from group_get_children(NEW.group_name))) = 't'
+        ) then
+            raise integrity_constraint_violation
+                using message =  NEW.group_member_name || ' already a member of ' || NEW.group_name;
         end if;
-        -- Ensure we have only Directed Acylic Graphs, where primary groups are only allowed in leaves
-        -- if a any of the groups are currently inactive or expired, the membership cannot be created
-        -- also disallow any self-referential entries
-        assert NEW.group_name != NEW.group_member_name, 'groups cannot be members of themselves';
-        response := NEW.group_name || ' is a primary group - which cannot have members other than its primary member';
-        assert (select NEW.group_name in
-            (select group_name from groups where group_class = 'primary')) = 'f', response;
-        assert (select group_activated from groups where group_name = NEW.group_name) = 't',
-            NEW.group_name || ' is deactived - to use it in new group memberships it must be active';
-        assert (select group_activated from groups where group_name = NEW.group_member_name) = 't',
-            NEW.group_member_name || ' is deactived - to use it in new group memberships it must be active';
-        assert (select case when group_expiry_date is not null then group_expiry_date else current_date end
-                from groups where group_name = NEW.group_name) >= current_date,
-            NEW.group_name || ' has expired - to use it in new group memberships its expiry date must be later than the current date';
-        assert (select case when group_expiry_date is not null then group_expiry_date else current_date end
-                from groups where group_name = NEW.group_member_name) >= current_date,
-            NEW.group_member_name || ' has expired - to use it in new group memberships its expiry date must be later than the current date';
-        response := 'Making ' || NEW.group_member_name || ' a member of ' || NEW.group_name
-                    || ' would create a cyclical graph which is not allowed';
-        assert (select NEW.group_member_name in
-            (select member_group_name from group_get_parents(NEW.group_name))) = 'f', response;
-        response := NEW.group_member_name || ' is already a member of ' || NEW.group_name;
-        assert (select NEW.group_member_name in
-            (select group_member_name from group_get_children(NEW.group_name))) = 'f', response;
         return new;
     end;
 $$ language plpgsql;

--- a/src/organisations.sql
+++ b/src/organisations.sql
@@ -36,13 +36,17 @@ create or replace function institution_immutability()
     returns trigger as $$
     begin
         if OLD.row_id != NEW.row_id then
-            raise exception using message = 'row_id is immutable';
+            raise integrity_constraint_violation
+            using message = 'row_id is immutable';
         elsif OLD.institution_id != NEW.institution_id then
-            raise exception using message = 'institution_id is immutable';
+            raise integrity_constraint_violation
+            using message = 'institution_id is immutable';
         elsif OLD.institution_name != NEW.institution_name then
-            raise exception using message = 'institution_name is immutable';
+            raise integrity_constraint_violation
+            using message = 'institution_name is immutable';
         elsif OLD.institution_group != NEW.institution_group then
-            raise exception using message = 'institution_group is immutable';
+            raise integrity_constraint_violation
+            using message = 'institution_group is immutable';
         end if;
     return new;
     end;
@@ -106,13 +110,17 @@ create or replace function project_immutability()
     returns trigger as $$
     begin
         if OLD.row_id != NEW.row_id then
-            raise exception using message = 'row_id is immutable';
+            raise integrity_constraint_violation
+            using message = 'row_id is immutable';
         elsif OLD.project_id != NEW.project_id then
-            raise exception using message = 'project_id is immutable';
+            raise integrity_constraint_violation
+            using message = 'project_id is immutable';
         elsif OLD.project_number != NEW.project_number then
-            raise exception using message = 'project_number is immutable';
+            raise integrity_constraint_violation
+            using message = 'project_number is immutable';
         elsif OLD.project_group != NEW.project_group then
-            raise exception using message = 'project_group is immutable';
+            raise integrity_constraint_violation
+            using message = 'project_group is immutable';
         end if;
     return new;
     end;

--- a/tests.sql
+++ b/tests.sql
@@ -564,10 +564,9 @@ create or replace function test_group_membership_constraints()
         -- start and end date constraints
         begin
             perform group_member_add('p12-lol-group', 'p12-brb', null, '2091-01-01');
-            assert false;
-        exception when others then
+            assert false, 'membership: end_date can exceed group expiry check works';
+        exception when integrity_constraint_violation then
             raise notice '%', sqlerrm;
-            raise notice 'membership: end_date cannot exceed group expiry check works';
         end;
         begin
             insert into group_memberships(
@@ -575,10 +574,9 @@ create or replace function test_group_membership_constraints()
             ) values (
                 'p12-admin-group', 'p12-brb-group', '2080-01-01', '2000-01-01'
             );
-            assert false;
+            assert false, 'membership: start_date < end_date check works';
         exception when check_violation then
             raise notice '%', sqlerrm;
-            raise notice 'membership: start_date < end_date check works';
         end;
         -- weekdays constraints
         begin
@@ -587,10 +585,9 @@ create or replace function test_group_membership_constraints()
             ) values (
                 'p12-admin-group', 'p12-brb-group', '{"Lol": {}}'::jsonb
             );
-            assert false;
-        exception when others then
+            assert false, 'membership: weekdays wrong key name refused';
+        exception when invalid_parameter_value then
             raise notice '%', sqlerrm;
-            raise notice 'membership: weekdays wrong key name refused';
         end;
         begin
             insert into group_memberships(
@@ -598,10 +595,9 @@ create or replace function test_group_membership_constraints()
             ) values (
                 'p12-admin-group', 'p12-brb-group', '{"mon": {"end": "12:00"}}'::jsonb
             );
-            assert false;
-        exception when others then
+            assert false, 'membership: weekdays missing start time';
+        exception when invalid_parameter_value then
             raise notice '%', sqlerrm;
-            raise notice 'membership: weekdays missing start time refused';
         end;
         begin
             insert into group_memberships(
@@ -609,10 +605,9 @@ create or replace function test_group_membership_constraints()
             ) values (
                 'p12-admin-group', 'p12-brb-group', '{"mon": {"start": "12:00"}}'::jsonb
             );
-            assert false;
-        exception when others then
+            assert false, 'membership: weekdays missing end date';
+        exception when invalid_parameter_value then
             raise notice '%', sqlerrm;
-            raise notice 'membership: weekdays missing start end refused';
         end;
         begin
             insert into group_memberships(
@@ -620,10 +615,9 @@ create or replace function test_group_membership_constraints()
             ) values (
                 'p12-admin-group', 'p12-brb-group', '{"mon": {"start": "13:00", "end": "12:00"}}'::jsonb
             );
-            assert false;
-        exception when others then
+            assert false, 'membership: weekdays start > end time';
+        exception when invalid_parameter_value then
             raise notice '%', sqlerrm;
-            raise notice 'membership: weekdays start > end time refused';
         end;
 
         -- create a valid membership graph
@@ -693,10 +687,9 @@ create or replace function test_group_membership_constraints()
         -- ensure working limits on client timestamp
         begin
             select group_members('p12-export-group', 't', (current_timestamp + interval '4 days')) into mems;
-            assert false;
-        exception when others then
+            assert false, 'membership: impossible client_timestamp refused';
+        exception when invalid_parameter_value then
             raise notice '%', sqlerrm;
-            raise notice 'membership: impossible client_timestamp refused';
         end;
 
         -- user_groups

--- a/tests.sql
+++ b/tests.sql
@@ -445,8 +445,6 @@ create or replace function test_group_memeberships_moderators()
             raise notice '%', sqlerrm;
         end;
 
-        -- safeguards in group_remove
-
         /* GROUP MODERATORS */
 
         insert into group_moderators (group_name, group_moderator_name)
@@ -489,9 +487,9 @@ create or replace function test_group_memeberships_moderators()
         begin
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-special-group', 'p11-clinical-group');
-
-        exception when assert_failure then
-            raise notice 'group_moderators: cyclicality check works';
+            assert false, 'group_moderators: cyclicality check not working';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- new relations and group activation state
         begin
@@ -500,9 +498,9 @@ create or replace function test_group_memeberships_moderators()
             update groups set group_activated = 'f' where group_name = 'p11-lol-group';
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-lol-group', 'p11-admin-group');
-
-        exception when assert_failure then
-            raise notice 'group_moderators: deactivated groups cannot be used';
+            assert false, 'group_moderators: deactivated groups can be used';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- new relations and group expiry
         begin
@@ -511,9 +509,9 @@ create or replace function test_group_memeberships_moderators()
             update groups set group_expiry_date = '2011-01-01' where group_name = 'p11-lol-group';
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-lol-group', 'p11-admin-group');
-
-        exception when assert_failure then
-            raise notice 'group_moderators: expired groups cannot be used';
+            assert false, 'group_moderators: expired groups cannot be used';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         update groups set group_expiry_date = '2011-01-01' where group_name = 'p11-export-group';
         --delete from persons;

--- a/tests.sql
+++ b/tests.sql
@@ -1326,29 +1326,29 @@ create or replace function test_institutions()
             update institutions set row_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
                 where institution_name = 'uil';
             assert false, 'institutions: row_id mutable';
-        exception when others then
-            raise notice 'institutions: row_id immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update institutions set institution_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
                 where institution_name = 'uil';
             assert false, 'institutions: institution_id mutable';
-        exception when others then
-            raise notice 'institutions: institution_id immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update institutions set institution_name = 'liu'
                 where institution_name = 'uil';
             assert false, 'institutions: institution_name mutable';
-        exception when others then
-            raise notice 'institutions: institution_name immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update institutions set institution_group = 'foo-group'
                 where institution_name = 'uil';
             assert false, 'institutions: institution_group mutable';
-        exception when others then
-            raise notice 'institutions: institution_group immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- groups
         select institution_group from institutions
@@ -1363,14 +1363,14 @@ create or replace function test_institutions()
         begin
             update groups set group_activated = 't' where group_name = grp;
             assert false, 'institution group activation mutable on groups';
-        exception when others then
-            raise notice 'institution group activation not mutable on groups';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update groups set group_expiry_date = '2020-01-01' where group_name = grp;
             assert false, 'institution group_expiry_date mutable on groups';
-        exception when others then
-            raise notice 'institution group_expiry_date not mutable on groups';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
         end;
         return true;
     end;
@@ -1393,29 +1393,29 @@ create or replace function test_projects()
             update projects set row_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
                 where project_name = 'raka';
             assert false, 'projects: row_id mutable';
-        exception when others then
+        exception when integrity_constraint_violation then
             raise notice 'projects: row_id immutable';
         end;
         begin
             update projects set project_id = '44c23dc9-d759-4c1f-a72e-04e10dbe2523'
                 where project_name = 'raka';
             assert false, 'projects: project_id mutable';
-        exception when others then
-            raise notice 'projects: project_id immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update projects set project_number = 'lolcat'
                 where project_name = 'raka';
             assert false, 'projects: project_number mutable';
-        exception when others then
-            raise notice 'projects: project_number immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update projects set project_group = 'some-group'
                 where project_name = 'raka';
             assert false, 'projects: project_group mutable';
-        exception when others then
-            raise notice 'projects: project_group immutable';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- groups
         select project_group from projects
@@ -1430,14 +1430,14 @@ create or replace function test_projects()
         begin
             update groups set group_activated = 't' where group_name = grp;
             assert false, 'project group activation mutable on groups';
-        exception when others then
-            raise notice 'project group activation not mutable on groups';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             update groups set group_expiry_date = '2020-01-01' where group_name = grp;
             assert false, 'project group_expiry_date mutable on groups';
-        exception when others then
-            raise notice 'project group_expiry_date not mutable on groups';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
         end;
         return true;
     end;

--- a/tests.sql
+++ b/tests.sql
@@ -1176,17 +1176,16 @@ create or replace function test_audit()
     returns boolean as $$
     declare pid uuid;
     declare rid uuid;
-    declare msg text;
+    declare grp text;
     begin
         select person_id from persons limit 1 into pid;
         select row_id from persons where person_id = pid into rid;
         update persons set person_activated = 'f' where person_id = pid;
-        msg := 'audit_log does not work';
-        -- todo: redo this, add relations audit table
-        --assert (select old_data from audit_log
-          --      where row_id = rid and column_name = 'person_activated') = 'true', msg;
-        --assert (select new_data from audit_log
-          --      where row_id = rid and column_name = 'person_activated') = 'false', msg;
+        assert (select count(*) from audit_log_objects
+                where row_id = rid) > 0, 'issue with audit_log_objects';
+        select group_name from groups where group_class = 'secondary' limit 1 into grp;
+        assert (select count(*) from audit_log_relations
+                where parent = grp) > 0, 'issue with audit_log_relations';
         return true;
     end;
 $$ language plpgsql;

--- a/tests.sql
+++ b/tests.sql
@@ -362,22 +362,22 @@ create or replace function test_group_memeberships_moderators()
         -- redundancy
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-export-group','p11-publication-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: redundancy check works';
+            assert false, 'group_memberships: redundancy check not working';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- cyclicality
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-export-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: cyclicality check works';
+            assert false, 'group_memberships: cyclicality check not working';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-admin-group','p11-export-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: cyclicality check works';
+            assert false, 'group_memberships: cyclicality check not working, for transitive members';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- immutability
         begin
@@ -395,32 +395,32 @@ create or replace function test_group_memeberships_moderators()
         -- group classes
         begin
             insert into group_memberships values ('p11-sconne-group', 'p11-special-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: primary groups cannot have new members';
+            assert false, 'group_memberships: primary groups cannot have new members';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- new relations and group activation state
         begin
             update groups set group_activated = 'f' where group_name = 'p11-import-group';
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-import-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: deactivated groups cannot be used in new relations';
+            assert false, 'group_memberships: deactivated groups cannot be used in new relations';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- new relations and group expiry
         begin
             update groups set group_expiry_date = '2017-01-01' where group_name = 'p11-import-group';
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-import-group');
-
-        exception when assert_failure then
-            raise notice 'group_memberships: expired groups cannot be used in new relations';
+            assert false, 'group_memberships: expired groups cannot be used in new relations';
+        exception when integrity_constraint_violation then
+            raise notice '%', sqlerrm;
         end;
         -- shouldnt be able to be a member of itself
         begin
             insert into group_memberships (group_name, group_member_name)
                 values ('p11-special-group', 'p11-special-group');
-            --assert false, 'group_memberships: redundancy check - groups can be members of themselves';
-        exception when assert_failure then
+            assert false, 'group_memberships: redundancy check - groups can be members of themselves';
+        exception when integrity_constraint_violation then
             raise notice '%', sqlerrm;
         end;
 

--- a/tests.sql
+++ b/tests.sql
@@ -258,6 +258,7 @@ create or replace function test_group_memeberships_moderators()
     returns boolean as $$
     declare pid uuid;
     declare row record;
+    declare out json;
     begin
         -- create persons and users
         insert into persons (full_name, person_expiry_date)
@@ -423,6 +424,28 @@ create or replace function test_group_memeberships_moderators()
         exception when integrity_constraint_violation then
             raise notice '%', sqlerrm;
         end;
+
+        -- safeguards in group_member_add
+        begin
+            perform group_member_add('lol-group', 'p11-import-group');
+            assert false, 'group_member_add does not detect non-existent group';
+        exception when invalid_parameter_value then
+            raise notice '%', sqlerrm;
+        end;
+        begin
+            perform group_member_add('p11-import-group', 'yeah-group');
+            assert false, 'group_member_add does not detect non-existent group';
+        exception when invalid_parameter_value then
+            raise notice '%', sqlerrm;
+        end;
+        begin
+            perform group_member_add('p11-import-group', '59c1987e-fa15-4509-9b4e-12557fdb9ed9');
+            assert false, 'group_member_add does not detect non-existent person_id';
+        exception when invalid_parameter_value then
+            raise notice '%', sqlerrm;
+        end;
+
+        -- safeguards in group_remove
 
         /* GROUP MODERATORS */
 

--- a/tests.sql
+++ b/tests.sql
@@ -362,20 +362,20 @@ create or replace function test_group_memeberships_moderators()
         -- redundancy
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-export-group','p11-publication-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: redundancy check works';
         end;
         -- cyclicality
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-export-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: cyclicality check works';
         end;
         begin
             insert into group_memberships (group_name, group_member_name) values ('p11-admin-group','p11-export-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: cyclicality check works';
         end;
@@ -401,7 +401,7 @@ create or replace function test_group_memeberships_moderators()
         -- group classes
         begin
             insert into group_memberships values ('p11-sconne-group', 'p11-special-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: primary groups cannot have new members';
         end;
@@ -409,7 +409,7 @@ create or replace function test_group_memeberships_moderators()
         begin
             update groups set group_activated = 'f' where group_name = 'p11-import-group';
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-import-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: deactivated groups cannot be used in new relations';
         end;
@@ -417,7 +417,7 @@ create or replace function test_group_memeberships_moderators()
         begin
             update groups set group_expiry_date = '2017-01-01' where group_name = 'p11-import-group';
             insert into group_memberships (group_name, group_member_name) values ('p11-publication-group','p11-import-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_memberships: expired groups cannot be used in new relations';
         end;
@@ -477,7 +477,7 @@ create or replace function test_group_memeberships_moderators()
         begin
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-special-group', 'p11-clinical-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_moderators: cyclicality check works';
         end;
@@ -486,7 +486,7 @@ create or replace function test_group_memeberships_moderators()
             update groups set group_activated = 'f' where group_name = 'p11-export-group';
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-export-group', 'p11-admin-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_moderators: deactivated groups cannot be used';
         end;
@@ -495,7 +495,7 @@ create or replace function test_group_memeberships_moderators()
             update groups set group_expiry_date = '2011-01-01' where group_name = 'p11-export-group';
             insert into group_moderators (group_name, group_moderator_name)
                 values ('p11-export-group', 'p11-admin-group');
-            assert false;
+
         exception when assert_failure then
             raise notice 'group_moderators: expired groups cannot be used';
         end;

--- a/tests.sql
+++ b/tests.sql
@@ -180,6 +180,20 @@ create or replace function test_persons_users_groups()
             'person state changes not propagating to users';
         assert (select count(*) from groups where group_activated = 't') = 0,
             'person state changes not propagating to groups';
+        begin
+            update groups set group_activated = 't'
+                where group_name = pid::text || '-group';
+            assert false, 'person groups can be dectivated directly on group table';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
+        end;
+        begin
+            update groups set group_activated = 't'
+                where group_name = 'p66-sconne-group';
+            assert false, 'user groups can be dectivated directly on group table';
+        exception when restrict_violation then
+            raise notice '%', sqlerrm;
+        end;
 
         -- expiry dates
         update persons set person_expiry_date = '2019-09-09';

--- a/tests.sql
+++ b/tests.sql
@@ -427,13 +427,13 @@ create or replace function test_group_memeberships_moderators()
 
         -- safeguards in group_member_add
         begin
-            perform group_member_add('lol-group', 'p11-import-group');
+            perform group_member_add('lol', 'p11-import-group');
             assert false, 'group_member_add does not detect non-existent group';
-        exception when invalid_parameter_value then
+        exception when foreign_key_violation then
             raise notice '%', sqlerrm;
         end;
         begin
-            perform group_member_add('p11-import-group', 'yeah-group');
+            perform group_member_add('p11-import-group', 'yeah');
             assert false, 'group_member_add does not detect non-existent group';
         exception when invalid_parameter_value then
             raise notice '%', sqlerrm;


### PR DESCRIPTION
This PR makes no logical changes.

Details:

* replace all calls to `assert` with `if` blocks - safer, because `assert` can be disabled
* raise more specific exceptions
* catch specific exceptions in tests, report the SQL error
* improve test coverage