### PR TITLE
Add group affiliations, adjust institutions and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ A generic database backend for use in IAM APIs.
 - add users and/or groups to groups, specify temporal constraints on memberships
 - add persons without users to groups, for external account access control management
 - allow groups to moderate memberships of other groups
+- affiliate groups with one another
 - create capabilities, criteria for obtaining them, use them in access tokens
 - specify the scope of the capabilities
+- create organisational units and hierarchies with institutions, and projects
+- affiliate groups with institutions and projects
 - data integrity and consistency, immutable columns wherever possible
 - audit log on all inserts, updates, and deletes
 - SQL functions for simplified application development

--- a/docs/1-data-model.md
+++ b/docs/1-data-model.md
@@ -5,8 +5,8 @@
 Persons -----> Users ----> Groups (class:primary,   type:user)
   -----------------------> Groups (class:primary,   type:person)
                         -> Groups (class:secondary type:generic,web)
-                            -> Groups (class:primary,secondary,web
-                                       relations: members, moderators)
+                            -> Groups (class:primary, secondary
+                                       relations: members, moderators, affiliates)
 
 Capabilities
   -> Name
@@ -24,17 +24,25 @@ Capability Grants
  -> HTTP method
  -> URI pattern
 
-Institutions -> Groups (class:secondary type:generic,web)
-Projects     -> Groups (class:secondary type:generic,web)
+Institutions -> Group (class:secondary type:institution)
+    -> Groups (class:primary, secondary
+               relations: members, affiliates)
+Projects     -> Group (class:primay type:project)
+    - Groups (class:primary, secondary
+              relation: affiliates)
 ```
 
 - `Persons`: root objects
 - `Users`: owned by `Persons`
 - `Groups`:
-    - `person` groups, class: `primary`, type: `person` and
-    - `user` groups, class: `primary`, type: `user` , automatically created, updated, deleted
-    - `generic` groups, class: `secondary`, type: `generic`
-    - `generic` groups, class: `secondary`, type: `web`, no posix ids
+    - class: `primary`, owned by other objects
+        - type: `person`, automatically created, updated, deleted
+        - type: `user`, automatically created, updated, deleted
+        - type: `project`, automatically created, updated, deleted
+    - class: `secondary`
+        - type: `institution`, automatically created, updated, deleted
+        - type: `generic`, assigned POSIX ID
+        - type: `web`, no posix ids
 - Group-to-group relations:
     - member
         - groups can be members of other groups
@@ -46,6 +54,9 @@ Projects     -> Groups (class:secondary type:generic,web)
             - can be limited to being active between specific hours on a specific day of the week
     - moderator
         - groups can moderate other groups, but not transitively or cyclically
+    - affiliates
+        - any group can be affiliated with another group
+        - not transitive
 - Activation
     - `persons`
         - a person's activation status determines their person group's status
@@ -84,9 +95,12 @@ Projects     -> Groups (class:secondary type:generic,web)
         - end date
         - maximum number of usages
 - `Institutions`
-    - generates an automatically managed secondary web group
+    - generates an automatically managed secondary institution group
+    - can have other groups as members
+    - can be have other groups as affiliates
 - `Projects`
-    - generates an automatically managed secondary web group
+    - generates an automatically managed primary project group
+    - can be have other groups as affiliates
 
 # Group membership graphs
 

--- a/docs/2-db-structure.md
+++ b/docs/2-db-structure.md
@@ -13,6 +13,7 @@ users
 groups
 group_memberships
 group_moderators
+group_affiliations
 capabilities_http
 capabilities_http_instances
 capabilities_http_grants
@@ -115,6 +116,18 @@ group_capabilities(group_name text)
     {group_name: '', group_capabilities: []}
 */
 
+group_affiliations(group_name text)
+/*
+    Returns:
+    {group_name: '', group_affiliations: []}
+*/
+
+group_affiliates(group_name text)
+/*
+    Returns:
+    {group_name: '', group_affiliates: []}
+*/
+
 capability_grant_rank_set(grant_id text, new_grant_rank int)
 /*
     Returns:
@@ -143,5 +156,65 @@ capability_grant_group_remove(grant_reference text, group_name text)
 /*
     Returns
     boolean
+*/
+
+institution_member_add(institution text, member text)
+/*
+    Returns
+    {message: ''}
+*/
+
+institution_member_remove(institution text, member text)
+/*
+    Returns
+    {message: ''}
+*/
+
+institution_members(institution text)
+/*
+    Returns
+    {group_name, ', group_members: []}
+*/
+
+institution_group_add(institution text, group_name text)
+/*
+    Returns
+    {message: ''}
+*/
+
+institution_group_remove(institution text, group_name text)
+/*
+    Returns
+    {message: ''}
+*/
+
+institution_groups(institution text)
+/*
+    Returns
+    {group_name: '', group_affiliates: []}
+*/
+
+project_group_add(project text, group_name text)
+/*
+    Returns
+    {message: ''}
+*/
+
+project_group_remove(project text, group_name text)
+/*
+    Returns
+    {message: ''}
+*/
+
+project_groups(proj)
+/*
+    Returns
+    {group_name: '', group_affiliates: []}
+*/
+
+project_institutions(proj)
+/*
+    Returns
+    {project: '', institutions: []}
 */
 ```

--- a/docs/3-example-data.sql
+++ b/docs/3-example-data.sql
@@ -160,3 +160,61 @@ select jsonb_pretty(
         (select person_id::text from users where user_name = 'jm'), 't'
     )::jsonb
 );
+
+insert into institutions(
+    institution_name, institution_long_name, institution_expiry_date
+) values (
+    'emanate', 'emanate - from which all creativity flows', '3000-01-01'
+);
+insert into institutions(
+    institution_name, institution_long_name, institution_expiry_date
+) values (
+    'surrealism-inc', 'surrealism incorporated - commoditising your dreams', '2050-10-11'
+);
+insert into projects(
+    project_number, project_name, project_start_date, project_end_date
+) values (
+    'p0', 'project zero', '2000-12-01', '2080-01-01'
+);
+insert into projects(
+    project_number, project_name, project_start_date, project_end_date
+) values (
+    'p1', 'project one', '2002-05-18', '2080-01-01'
+);
+insert into groups (
+    group_name, group_class, group_type
+) values (
+    'surrealism-inc-admin-group', 'secondary', 'web'
+);
+insert into groups (
+    group_name, group_class, group_type
+) values (
+    'p0-admin-group', 'secondary', 'generic'
+);
+insert into groups (
+    group_name, group_class, group_type
+) values (
+    'p0-weirdo-group', 'secondary', 'generic'
+);
+
+select institution_member_add('emanate', 'surrealism-inc');
+select institution_member_add('surrealism-inc', 'p0');
+select institution_member_add('surrealism-inc', 'p1');
+
+select jsonb_pretty(institution_members('emanate')::jsonb);
+
+select institution_group_add('surrealism-inc', 'surrealism-inc-admin-group');
+select project_group_add('p0', 'p0-admin-group');
+select project_group_add('p0', 'p0-weirdo-group');
+
+select jsonb_pretty(institution_groups('surrealism-inc')::jsonb);
+select jsonb_pretty(project_groups('p0')::jsonb);
+
+insert into group_affiliations (
+    parent_group, child_group
+) values (
+    'surrealism-inc-admin-group', 'p0-admin-group'
+);
+
+select jsonb_pretty(group_affiliates('surrealism-inc-admin-group')::jsonb);
+select jsonb_pretty(group_affiliations('p0-admin-group')::jsonb);

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -98,3 +98,7 @@ create or replace function group_immutability()
     return new;
     end;
 $$ language plpgsql;
+
+-- audit
+create table if not exists audit_log_relations_group_moderators
+    partition of audit_log_relations for values in ('group_affiliations');

--- a/mgrt/2.2-to-2.3.sql
+++ b/mgrt/2.2-to-2.3.sql
@@ -1,4 +1,6 @@
 
+set session "session.identity" = 'db-migration';
+
 alter table group_memberships add column if not exists start_date timestamptz;
 alter table group_memberships add column if not exists end_date timestamptz;
 alter table group_memberships add column if not exists weekdays jsonb;
@@ -7,3 +9,92 @@ alter table group_memberships add constraint group_memberships_check check (star
 alter table audit_log_relations add column if not exists start_date timestamptz;
 alter table audit_log_relations add column if not exists end_date timestamptz;
 alter table audit_log_relations add column if not exists weekdays jsonb;
+
+-- make group_class, group_type mutable
+create or replace function group_immutability()
+    returns trigger as $$
+    begin
+        if OLD.row_id != NEW.row_id then
+            raise integrity_constraint_violation
+                using message = 'row_id is immutable';
+        elsif OLD.group_id != NEW.group_id then
+            raise integrity_constraint_violation
+                using message = 'group_id is immutable';
+        elsif OLD.group_name != NEW.group_name then
+            raise integrity_constraint_violation
+                using message = 'group_name is immutable';
+        elsif OLD.group_primary_member != NEW.group_primary_member then
+            raise integrity_constraint_violation
+                using message = 'group_primary_member is immutable';
+        elsif OLD.group_posix_gid != NEW.group_posix_gid then
+            raise integrity_constraint_violation
+                using message = 'group_posix_gid is immutable';
+        elsif NEW.group_posix_gid is null and OLD.group_posix_gid is not null then
+            raise integrity_constraint_violation
+                using message = 'group_posix_gid cannot be set to null once set';
+        end if;
+    return new;
+    end;
+$$ language plpgsql;
+
+-- define new group type
+alter table groups drop constraint groups_group_type_check;
+alter table groups add constraint groups_group_type_check
+    check (group_type in ('person', 'user', 'generic', 'web', 'project', 'institution'));
+
+-- change project groups
+update groups set group_class = 'primary', group_type = 'project'
+    where group_name in (select project_group from projects);
+
+create or replace function update_organisational_groups()
+    returns void as $$
+    declare pnum text;
+    declare grp text;
+    begin
+        for pnum, grp in select project_number, project_group from projects loop
+            raise info 'updating % -> primary member: %', grp, pnum;
+            update groups set group_primary_member = pnum
+                where group_name = grp;
+        end loop;
+        for grp in select institution_group from institutions loop
+            raise info 'updating % -> group_type: institution', grp;
+            update groups set group_type = 'institution'
+                where group_name = grp;
+        end loop;
+    end;
+$$ language plpgsql;
+
+select update_organisational_groups();
+
+-- make group_class, group_type immutable again
+create or replace function group_immutability()
+    returns trigger as $$
+    begin
+        if OLD.row_id != NEW.row_id then
+            raise integrity_constraint_violation
+                using message = 'row_id is immutable';
+        elsif OLD.group_id != NEW.group_id then
+            raise integrity_constraint_violation
+                using message = 'group_id is immutable';
+        elsif OLD.group_name != NEW.group_name then
+            raise integrity_constraint_violation
+                using message = 'group_name is immutable';
+        elsif OLD.group_class != NEW.group_class then
+            raise integrity_constraint_violation
+                using message = 'group_class is immutable';
+        elsif OLD.group_type != NEW.group_type then
+            raise integrity_constraint_violation
+                using message = 'group_type is immutable';
+        elsif OLD.group_primary_member != NEW.group_primary_member then
+            raise integrity_constraint_violation
+                using message = 'group_primary_member is immutable';
+        elsif OLD.group_posix_gid != NEW.group_posix_gid then
+            raise integrity_constraint_violation
+                using message = 'group_posix_gid is immutable';
+        elsif NEW.group_posix_gid is null and OLD.group_posix_gid is not null then
+            raise integrity_constraint_violation
+                using message = 'group_posix_gid cannot be set to null once set';
+        end if;
+    return new;
+    end;
+$$ language plpgsql;

--- a/src/audit.sql
+++ b/src/audit.sql
@@ -62,6 +62,8 @@ create table if not exists audit_log_relations_group_memberships
     partition of audit_log_relations for values in ('group_memberships');
 create table if not exists audit_log_relations_group_moderators
     partition of audit_log_relations for values in ('group_moderators');
+create table if not exists audit_log_relations_group_affiliations
+    partition of audit_log_relations for values in ('group_affiliations');
 
 
 drop function if exists update_audit_log_objects() cascade;
@@ -125,6 +127,9 @@ create or replace function update_audit_log_relations()
             elsif table_name = 'group_moderators' then
                 parent := NEW.group_name;
                 child := NEW.group_moderator_name;
+            elsif table_name = 'group_affiliations' then
+                parent := NEW.parent_group;
+                child := NEW.child_group;
             end if;
         elsif TG_OP = 'DELETE' then
             if table_name = 'group_memberships' then
@@ -136,6 +141,9 @@ create or replace function update_audit_log_relations()
             elsif table_name = 'group_moderators' then
                 parent := OLD.group_name;
                 child := OLD.group_moderator_name;
+            elsif table_name = 'group_affiliations' then
+                parent := OLD.parent_group;
+                child := OLD.child_group;
             end if;
         end if;
         insert into audit_log_relations(

--- a/src/organisations.sql
+++ b/src/organisations.sql
@@ -64,8 +64,8 @@ create or replace function institution_management()
             new_grp := NEW.institution_name || '-group';
             update institutions set institution_group = new_grp
                 where institution_name = NEW.institution_name;
-            insert into groups (group_name, group_class, group_type, group_description)
-                values (new_grp, 'secondary', 'web', 'institution group');
+            insert into groups (group_name, group_class, group_type, group_expiry_date, group_description)
+                values (new_grp, 'secondary', 'web', NEW.institution_expiry_date, 'institution group');
         elsif (TG_OP = 'DELETE') then
             delete from groups where group_name = OLD.institution_group;
         elsif (TG_OP = 'UPDATE') then
@@ -138,8 +138,8 @@ create or replace function project_management()
             new_grp := NEW.project_number || '-group';
             update projects set project_group = new_grp
                 where project_number = NEW.project_number;
-            insert into groups (group_name, group_class, group_type, group_description)
-                values (new_grp, 'secondary', 'web', 'project group');
+            insert into groups (group_name, group_class, group_type, group_expiry_date, group_description)
+                values (new_grp, 'secondary', 'web', NEW.project_end_date, 'project group');
         elsif (TG_OP = 'DELETE') then
             delete from groups where group_name = OLD.project_group;
         elsif (TG_OP = 'UPDATE') then

--- a/tests.sql
+++ b/tests.sql
@@ -1846,5 +1846,5 @@ drop function if exists test_audit();
 drop function if exists test_funcs();
 drop function if exists test_institutions();
 drop function if exists test_projects();
-drop function if exists test_organisations;
+drop function if exists test_organisations();
 drop function if exists test_cascading_deletes(boolean);

--- a/tests.sql
+++ b/tests.sql
@@ -1451,8 +1451,8 @@ create or replace function test_institutions()
     returns boolean as $$
     declare grp text;
     begin
-        insert into institutions (institution_name, institution_long_name)
-            values ('uil', 'University of Leon');
+        insert into institutions (institution_name, institution_long_name, institution_expiry_date)
+            values ('uil', 'University of Leon', '2060-01-01');
         -- defaults
         assert (select institution_group from institutions
                 where institution_name = 'uil') = 'uil-group',
@@ -1496,6 +1496,9 @@ create or replace function test_institutions()
             'institution group not generated correctly';
         assert (select group_type from groups where group_name = grp) = 'web',
             'institution group generated with incorrect type';
+        -- syncing exp dates
+        assert (select group_expiry_date from groups where group_name = grp) = '2060-01-01',
+            'institution_expiry_date not being synced to groups on creation';
         update institutions set institution_activated = 'f' where institution_name = 'uil';
         assert (select group_activated from groups where group_name = grp) = 'f',
             'institution group activation status management not working';
@@ -1563,6 +1566,8 @@ create or replace function test_projects()
             'project group generation not working';
         assert (select group_type from groups where group_name = grp) = 'web',
             'project group generated with incorrect type';
+        assert (select group_expiry_date from groups where group_name = grp) = '2050-01-01',
+            'project_end_date not being synced to groups on creation';
         update projects set project_activated = 'f' where project_group = grp;
         assert (select group_activated from groups where group_name = grp) = 'f',
             'project group management not working';
@@ -1639,6 +1644,7 @@ select test_capability_instances();
 select test_funcs();
 select test_institutions();
 select test_projects();
+select test_organisations();
 select test_cascading_deletes(:keep_test);
 
 drop function if exists check_no_data(boolean);
@@ -1650,4 +1656,5 @@ drop function if exists test_audit();
 drop function if exists test_funcs();
 drop function if exists test_institutions();
 drop function if exists test_projects();
+drop function if exists test_organisations;
 drop function if exists test_cascading_deletes(boolean);


### PR DESCRIPTION
Summary:
* a new table is added for recording affiliations between groups (no semantics are enforced)
* ensure end dates are synced from projects and institutions to groups on creation
* new group types: `project`, `institution`
* project groups are now `primary` groups - project numbers set as primary members
* new DB functions to work with organisational units and affiliations

Example use cases:
* assigning rights at different organisational levels - e.g. an institutional administrator, which is able to administer all projects which belong to that institution: could be done by creating an admin group affiliated with the institution, and then affiliating it with all the project admin groups
* it is now possible to keep track of which groups belong to which projects and institutions by using affiliations