### PR TITLE
Verify that generated UID/GID are unused

### DIFF
--- a/src/identities.sql
+++ b/src/identities.sql
@@ -161,7 +161,7 @@ create or replace function generate_new_posix_id(
     returns int as $$
     declare current_max_id int;
     declare new_id int;
-    declare column_exists boolean;
+    declare posix_id_in_use boolean;
     begin
         execute format('select max(new_data::int) from %I where column_name = %s',
             quote_ident(table_name), quote_literal(colum_name))
@@ -176,8 +176,8 @@ create or replace function generate_new_posix_id(
         loop
             execute format('select 1 from %I where %I = %s',
                 quote_ident(objects_table), quote_ident(colum_name), quote_literal(new_id))
-                into column_exists;
-            if column_exists then
+                into posix_id_in_use;
+            if posix_id_in_use then
                 new_id := new_id + 1;
             else
                 return new_id;


### PR DESCRIPTION
Instead of only returning the current highest known ID according to audit logs, this PR adds adds an extra safety check for whether the ID is already in use before returning.

This was implemented by:
1. Adding a function parameter `objects_table` to `generate_new_posix_id()` to specify which table to check for prior usage.
2. Querying the `objects_table` tables prior to returning `new_id`, to ensure the ID is not used anywhere, and incrementing until an unused ID is found.