### PR TITLE
Add advisory locks to POSIX ID generation

### DIFF
--- a/docs/advisory-locks.md
+++ b/docs/advisory-locks.md
@@ -1,0 +1,12 @@
+# pg-iam advisory lock registry
+
+## Namespaces
+
+* **1000**: POSIX ID allocation
+
+## Locks
+
+| Namespace | Resource | Purpose                                 |
+| --------- | -------- | --------------------------------------- |
+| 1000      | 1        | UID allocation (generate_new_posix_uid) |
+| 1000      | 2        | GID allocation (generate_new_posix_gid) |

--- a/src/identities.sql
+++ b/src/identities.sql
@@ -194,6 +194,10 @@ create or replace function generate_new_posix_uid()
     returns int as $$
     declare new_uid int;
     begin
+        -- Serialize UID allocation globally across all transactions
+        -- Lock namespace 1000 (POSIX ID allocation), resource 1 (UID)
+        PERFORM pg_advisory_xact_lock(1000, 1);
+
         select generate_new_posix_id('audit_log_objects_users', 'user_posix_uid', 'users') into new_uid;
         return new_uid;
     end;
@@ -314,6 +318,10 @@ create or replace function generate_new_posix_gid()
     returns int as $$
     declare new_gid int;
     begin
+        -- Serialize GID allocation globally across all transactions
+        -- Lock namespace 1000 (POSIX ID allocation), resource 2 (GID)
+        PERFORM pg_advisory_xact_lock(1000, 2);
+
         select generate_new_posix_id('audit_log_objects_groups', 'group_posix_gid', 'groups') into new_gid;
         return new_gid;
     end;


### PR DESCRIPTION
Our functions `generate_new_posix_uid()`/`generate_new_posix_gid()` are used in user and group creation, and will return the same value until used, i.e. a new object has been INSERTed into the relevant table. If two users/groups were created concurrently then one of the INSERTs would fail the `unique` constraint of these ids.

tsd-iam tried to address this with `LOCK TABLE $table IN SHARE MODE` before creating these objects, but to me it seems heavy-handed having to lock the whole table to a single writer if you just need to ensure consistent POSIX IDs, and it also didn't seem to work well when multiple writers want to INSERT INTO groups when I ran some write-heavy tests:

```
2026-05-08 15:05:58 GMT [497] testuser@tsdiam ERROR:  deadlock detected
2026-05-08 15:05:58 GMT [497] testuser@tsdiam DETAIL:
    Process 497 waits for RowExclusiveLock on relation 16569 of database 16384; blocked by process 498.
    Process 498 waits for RowExclusiveLock on relation 16569 of database 16384; blocked by process 497.
    Process 497: INSERT INTO groups (...) VALUES (...) RETURNING group_posix_gid
    Process 498: INSERT INTO groups (...) VALUES (...) RETURNING group_posix_gid
```

Basically when you have concurrent workloads you can easily end up with this type of scenario:

1. Transaction A: `LOCK TABLE groups IN SHARE MODE`
2. Transaction B: `LOCK TABLE groups IN SHARE MODE`
3. Transaction A: `INSERT INTO groups` -> wait for transaction B to release lock
4. Transaction B: `INSERT INTO groups` -> wait for transaction A to release lock
5. Postgres detects the deadlock after configured interval and aborts one of the transactions

SHARE MODE locking basically prevents anyone else from writing to the table, but can be invoked by multiple transactions and is a guaranteed deadlock if both attempt to write.

`pg_advisory_xact_lock()` obtains an *exclusive* transaction-level lock and waits if necessary, which I thought seemed appropriate for the POSIX ID usecase. See [Postgres documentation on advisory locks](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS) for more details on this functionality.

This will be a bottleneck for user/group creations, since only one transaction can obtain an ID at once, but I think it's in line with what we want. Getting this uniqueness guarantee from pg-iam itself will allow tsd-iam to stop locking the tables on INSERT.